### PR TITLE
change app.listento match EXPOSE port, add a start script ref

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,5 +8,5 @@ app.get('/', function (req, res) {
   res.send('<html><body>Hello Kennel Club! Request served by container ' + hostname + '</body></html>');
 });
 
-app.listen(80);
+app.listen(8080);
 console.log('Running on http://localhost');

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "author": "Alex Kretzschmar",
   "dependencies": {
     "express": "4.12.0"
+  },
+  "scripts": {
+        "start": "node index.js"
   }
 }


### PR DESCRIPTION
Changes to make the node app work on OpenShift. Fixes the start script problem:

```
npm start
npm ERR! Linux 4.6.7-300.fc24.x86_64
npm ERR! argv "/usr/bin/node" "/usr/bin/npm" "start"
npm ERR! node v4.5.0
npm ERR! npm  v2.15.9

npm ERR! missing script: start
```

and the fact that a normal user cannot bind to port 80:

```
npm start                                                                                                                                                                                          

> node-hello-world@0.0.1 start /home/david/foo/kennel-club
> node index.js

Running on http://localhost
events.js:141
      throw er; // Unhandled 'error' event
      ^

Error: listen EACCES 0.0.0.0:80
    at Object.exports._errnoException (util.js:907:11)
    at exports._exceptionWithHostPort (util.js:930:20)
    at Server._listen2 (net.js:1237:19)
    at listen (net.js:1286:10)
    at Server.listen (net.js:1382:5)
    at EventEmitter.app.listen (/home/david/foo/kennel-club/node_modules/express/lib/application.js:595:24)
    at Object.<anonymous> (/home/david/foo/kennel-club/index.js:11:5)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
```
